### PR TITLE
feat!: rename 'common' config area to 'global'

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -11,8 +11,8 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
 	"github.com/techsquidtv/uhs-cli/cmd/shared"
-	"github.com/techsquidtv/uhs-cli/models/common"
 	"github.com/techsquidtv/uhs-cli/models/config"
+	"github.com/techsquidtv/uhs-cli/models/global"
 	"github.com/techsquidtv/uhs-cli/models/service/servicemap"
 )
 
@@ -32,7 +32,7 @@ var configureCmd = &cobra.Command{
 			selectedServices = args
 		}
 		uhsConfig := config.Config{
-			Common:   common.New(),
+			Global:   global.NewGlobal(),
 			Services: make(config.ServicesConfig),
 		}
 		sort.Strings(serviceNames)

--- a/cmd/default.go
+++ b/cmd/default.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/techsquidtv/uhs-cli/cmd/shared"
-	"github.com/techsquidtv/uhs-cli/models/common"
 	"github.com/techsquidtv/uhs-cli/models/config"
+	"github.com/techsquidtv/uhs-cli/models/global"
 	"github.com/techsquidtv/uhs-cli/models/service/servicemap"
 )
 
@@ -21,7 +21,7 @@ var defaultCmd = &cobra.Command{
 		This will output the default configuration file, meant to be overwritten manually of via the configure command.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		uhsConfig := config.Config{
-			Common:   common.New(),
+			Global:   global.NewGlobal(),
 			Services: make(config.ServicesConfig),
 		}
 

--- a/models/config/config.go
+++ b/models/config/config.go
@@ -3,15 +3,14 @@ package config
 import (
 	"fmt"
 
-	"github.com/techsquidtv/uhs-cli/models/common"
 	"github.com/techsquidtv/uhs-cli/models/config/manager"
 	"github.com/techsquidtv/uhs-cli/models/service/servicemap"
 	"gopkg.in/yaml.v3"
 )
 
 type Config struct {
-	Common   *common.Common `yaml:"common,omitempty"`
-	Services ServicesConfig `yaml:"services"`
+	Global   manager.Configurer `yaml:"global,omitempty"`
+	Services ServicesConfig     `yaml:"services"`
 }
 
 type ServicesConfig map[string]manager.Configurer

--- a/models/global/global.go
+++ b/models/global/global.go
@@ -1,14 +1,16 @@
-package common
+package global
 
 import (
 	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/techsquidtv/uhs-cli/models/config/manager"
 )
 
-type Common struct {
+type Global struct {
 	TZ      string  `yaml:"tz"`
 	Network Network `yaml:"network"`
+	Domain  string  `yaml:"domain"`
 	Certs   Certs   `yaml:"certs"`
 }
 
@@ -22,9 +24,10 @@ type Certs struct {
 	SSLDHParam        string `yaml:"ssl_dhparam"`
 }
 
-func New() *Common {
-	return &Common{
-		TZ: "America/New_York",
+func NewGlobal() manager.Configurer {
+	return &Global{
+		TZ:     "America/New_York",
+		Domain: "UltimateHomeServer.com",
 		Network: Network{
 			Gateway: "192.168.1.1",
 		},
@@ -36,12 +39,21 @@ func New() *Common {
 	}
 }
 
-func (c *Common) Configure() {
+func (c *Global) Configure() {
+	inputDomain := &survey.Input{
+		Message: "Enter your domain:",
+		Default: c.Domain,
+	}
+	err := survey.AskOne(inputDomain, &c.Domain)
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+
 	inputTz := &survey.Input{
 		Message: "Enter your timezone:",
 		Default: c.TZ,
 	}
-	err := survey.AskOne(inputTz, &c.TZ)
+	err = survey.AskOne(inputTz, &c.TZ)
 	if err != nil {
 		fmt.Println(err.Error())
 	}
@@ -82,3 +94,5 @@ func (c *Common) Configure() {
 		fmt.Println(err.Error())
 	}
 }
+
+func (c *Global) Fill(data []byte) error { return nil }


### PR DESCRIPTION
Renames the `common` area of the config to `global` to match the standard convention for helm charts, where these values will be accessible to any subcharts.

This also brings the `global` data-structure in line with how services are configured.

https://helm.sh/docs/chart_template_guide/subcharts_and_globals/#global-chart-values